### PR TITLE
Add a GitHub build to golden container workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,8 +55,6 @@ jobs:
         registry: ${{ env.IMAGE_REGISTRY }}
         image: ${{ steps.build-image.outputs.image }}
         tags: ${{ steps.build-image.outputs.tags }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Sign image with GitHub OIDC Token
       run: cosign sign --yes ${IMAGE_REGISTRY}/${IMAGE_REPO}@${DIGEST}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,16 +25,16 @@ jobs:
       digest: ${{ steps.push-image.outputs.digest }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
     - name: Install Cosign
-      uses: sigstore/cosign-installer@main
+      uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3.1.1
 
     - name: Install Syft
-      uses: anchore/sbom-action/download-syft@v0.14.3
+      uses: anchore/sbom-action/download-syft@78fc58e266e87a38d4194b2137a3d4e9bcaf7ca1 # v0.14.3
 
     - name: Log in to ghcr
-      uses: redhat-actions/podman-login@v1
+      uses: redhat-actions/podman-login@9184318aae1ee5034fbfbacc0388acf12669171f # v1
       with:
         registry: ${{ env.IMAGE_REGISTRY }}
         username: ${{ github.actor }}
@@ -42,7 +42,7 @@ jobs:
 
     - name: Buildah Action
       id: build-image
-      uses: redhat-actions/buildah-build@v2
+      uses: redhat-actions/buildah-build@b4dc19b4ba891854660ab1f88a097d45aa158f76 # v2
       with:
         image: ${{ env.IMAGE_REPO }}
         tags: ${{ env.IMAGE_TAGS }}
@@ -50,7 +50,7 @@ jobs:
 
     - name: Push to ghcr
       id: push-image
-      uses: redhat-actions/push-to-registry@v2
+      uses: redhat-actions/push-to-registry@9986a6552bc4571882a4a67e016b17361412b4df #v2
       with:
         registry: ${{ env.IMAGE_REGISTRY }}
         image: ${{ steps.build-image.outputs.image }}
@@ -76,7 +76,7 @@ jobs:
       actions: read # for detecting the Github Actions environment.
       id-token: write # for creating OIDC tokens for signing.
       packages: write # for uploading attestations.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.7.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.7.0 
     with:
       image: ${{ needs.build.outputs.image }}
       digest: ${{ needs.build.outputs.digest }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,85 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  IMAGE_REGISTRY: ghcr.io
+  IMAGE_REPO: ${{ github.repository_owner }}/golden-container
+  IMAGE_TAGS: latest
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Needed for signing the container image with GitHub OIDC Token
+      id-token: write
+      # Needed to push to ghcr.io registry
+      packages: write
+
+    outputs:
+      image:  ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}
+      digest: ${{ steps.push-image.outputs.digest }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@main
+
+    - name: Install Syft
+      uses: anchore/sbom-action/download-syft@v0.14.3
+
+    - name: Log in to ghcr
+      uses: redhat-actions/podman-login@v1
+      with:
+        registry: ${{ env.IMAGE_REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Buildah Action
+      id: build-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ env.IMAGE_REPO }}
+        tags: ${{ env.IMAGE_TAGS }}
+        dockerfiles: ./Containerfile
+
+    - name: Push to ghcr
+      id: push-image
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        registry: ${{ env.IMAGE_REGISTRY }}
+        image: ${{ steps.build-image.outputs.image }}
+        tags: ${{ steps.build-image.outputs.tags }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Sign image with GitHub OIDC Token
+      run: cosign sign --yes ${IMAGE_REGISTRY}/${IMAGE_REPO}@${DIGEST}
+      env:
+        DIGEST: ${{ steps.push-image.outputs.digest }}
+
+    - name: Generate and store SBOM
+      run: |
+          syft "${IMAGE_REGISTRY}/${IMAGE_REPO}@${DIGEST}" -o spdx-json=sbom-spdx.json
+          cosign attest --yes --predicate sbom-spdx.json --type spdx "${IMAGE_REGISTRY}/${IMAGE_REPO}@${DIGEST}"
+      env:
+        DIGEST: ${{ steps.push-image.outputs.digest }}
+
+  provenance:
+    needs: [build]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.7.0
+    with:
+      image: ${{ needs.build.outputs.image }}
+      digest: ${{ needs.build.outputs.digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
If any changes are pushed to the "golden-container" repository, release.yaml workflow will automatically run. It will build an image and sign it to be used for keyless validation.

https://issues.redhat.com/browse/HACBS-2434
Code refactored from https://github.com/mbestavros/festoji