### PR TITLE
Add a validate action to the GoldenContainer build workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,3 +81,14 @@ jobs:
       registry-username: ${{ github.actor }}
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+  validate:
+    needs: provenance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate image
+        uses: enterprise-contract/action-validate-image@v1.1
+        with:
+          image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}:${{ env.DIGEST }}
+          identity: https:\/\/github\.com\/(slsa-framework\/slsa-github-generator|${{ github.actor }}\/${{ github.event.repository.name }})\/
+          issuer: https://token.actions.githubusercontent.com


### PR DESCRIPTION
This PR introduces a new step in the Golden Container workflow named 'release.yaml'. After the container image is built and pushed , this new step validates the image using action-validate-image.
Jira :  https://issues.redhat.com/browse/HACBS-2450