### PR TITLE
FIX: Update to change identity to github repository owner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,5 +90,5 @@ jobs:
         uses: enterprise-contract/action-validate-image@v1.1
         with:
           image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}:${{ env.DIGEST }}
-          identity: https:\/\/github\.com\/(slsa-framework\/slsa-github-generator|${{ github.actor }}\/${{ github.event.repository.name }})\/
+          identity: https:\/\/github\.com\/(slsa-framework\/slsa-github-generator|${{ github.event.repository.name }}\/${{ github.event.repository.name }})\/
           issuer: https://token.actions.githubusercontent.com


### PR DESCRIPTION
#101 Fix to switch identity from ${{ github.actor }} to ${{ github.repository_owner }} to resolve username display issue in enterprise-contract/golden-container repo. See example: [GitHub Actions Log](https://github.com/enterprise-contract/golden-container/actions/runs/6157242552/job/16707903127#step:3:13).