### PR TITLE
[bug] Update to add 'latest' to release workflow for validate action  

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate image
-        uses: enterprise-contract/action-validate-image@v1.1
+        uses: enterprise-contract/action-validate-image@latest
         with:
           image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}:${{ env.DIGEST }}
           identity: https:\/\/github\.com\/(slsa-framework\/slsa-github-generator|${{ github.repository_owner }}\/${{ github.event.repository.name }})\/


### PR DESCRIPTION
This is to fix from updating action-validate-image to automatic release workflow.
REF: https://github.com/enterprise-contract/action-validate-image/pull/10
resolves: HACBS-2725
