### PR TITLE
Add step to tag image as `latest-validated` after validation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 env:
   IMAGE_REGISTRY: ghcr.io
   IMAGE_REPO: ${{ github.repository_owner }}/golden-container
-  IMAGE_TAGS: latest
+  IMAGE_TAGS: ${{ github.sha }}
 
 jobs:
   build:
@@ -83,12 +83,24 @@ jobs:
       registry-password: ${{ secrets.GITHUB_TOKEN }}
 
   validate:
-    needs: provenance
+    needs: [provenance, build]
     runs-on: ubuntu-latest
     steps:
       - name: Validate image
         uses: enterprise-contract/action-validate-image@v1.0.1
         with:
-          image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}:${{ env.DIGEST }}
+          image: ${{ needs.build.outputs.image }}@${{ needs.build.outputs.digest }}
           identity: https:\/\/github\.com\/(slsa-framework\/slsa-github-generator|${{ github.repository_owner }}\/${{ github.event.repository.name }})\/
           issuer: https://token.actions.githubusercontent.com
+    
+  promote:
+    runs-on: ubuntu-latest
+    needs: [validate, build]
+    steps:  
+      - name: Push latest-validated image tag 
+        run: |
+          skopeo copy \
+          --dest-creds=${{ github.actor }}:${{ github.token }} \
+          docker://${{ needs.build.outputs.image }}@${{ needs.build.outputs.digest }} \
+          docker://${{ needs.build.outputs.image }}:latest
+  


### PR DESCRIPTION
Introduces a new job in the GitHub Actions workflow to tag the image as `latest-validated` if it passes the validation. This ensures that only validated images receive this tag, providing a safer option than using the `latest` tag, which may include failed validated  images.

link: https://issues.redhat.com/browse/EC-63

