### PR TITLE
Build to "official" repo on push

### DIFF
--- a/.tekton/golden-container-push.yaml
+++ b/.tekton/golden-container-push.yaml
@@ -22,7 +22,7 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtap-contract-tenant/golden-container/golden-container:{{revision}}
+    value: quay.io/redhat-appstudio/ec-golden-image:{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/golden-container-tag-latest.yaml
+++ b/.tekton/golden-container-tag-latest.yaml
@@ -36,8 +36,8 @@ spec:
               image: registry.access.redhat.com/ubi9/skopeo:latest@sha256:b7fa62dcc48dcb5e29a3fc99a889f66faf0e493373eb837ba184ca6ba922342b
               script: |
                 #!/usr/bin/env bash
-                SRC_REF=quay.io/redhat-user-workloads/rhtap-contract-tenant/golden-container/golden-container:$(params.revision)
-                TARGET_REF=quay.io/redhat-user-workloads/rhtap-contract-tenant/golden-container/golden-container:latest
+                SRC_REF=quay.io/redhat-appstudio/ec-golden-image:$(params.revision)
+                TARGET_REF=quay.io/redhat-appstudio/ec-golden-image:latest
 
                 retries=0
                 while ! skopeo inspect docker://${SRC_REF} >/dev/null 2>&1; do


### PR DESCRIPTION
I'm trying this out to see if it works. This would prevent us from having to do a "release" for this image, which would be nice.

I have already added a secret to our tenant to be able to push to the repo. :crossed_fingers: 