### PR TITLE
Copy the entire manifest list when tagging latest

### DIFF
--- a/.tekton/golden-container-tag-latest.yaml
+++ b/.tekton/golden-container-tag-latest.yaml
@@ -53,4 +53,4 @@ spec:
                 echo
                 echo ${SRC_REF} has been pushed, copying to ${TARGET_REF}
 
-                skopeo copy docker://${SRC_REF} docker://${TARGET_REF}
+                skopeo copy docker://${SRC_REF} docker://${TARGET_REF} --all


### PR DESCRIPTION
skopeo only copies over the amd64 image manifest unless explicitly specified by adding the --all option.