### PR TITLE
Set vendor label to Red Hat, Inc.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -5,7 +5,7 @@ ARG TARGETARCH
 ARG BUILD_DATE
 
 LABEL name="Enterprise Contract Golden Container" \
-      vendor="Enterprise Contract" \
+      vendor="Red Hat, Inc." \
       maintainer="hacbs-contract@redhat.com" \
       version="1" \
       release="1" \


### PR DESCRIPTION
Unless the vendor label is set to "Red Hat, Inc." the manifest files are not fetched from the container image and passed on to policies as input data.