### PR TITLE
Check only amd64 images in deprecated-iamge-check

### DIFF
--- a/.tekton/golden-container-pull-request.yaml
+++ b/.tekton/golden-container-pull-request.yaml
@@ -347,9 +347,9 @@ spec:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container-amd64.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
-        value: $(tasks.build-container.results.IMAGE_URL)
+        value: $(tasks.build-container-amd64.results.IMAGE_URL)
       - name: IMAGE_DIGEST
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
+        value: $(tasks.build-container-amd64.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/golden-container-push.yaml
+++ b/.tekton/golden-container-push.yaml
@@ -344,9 +344,9 @@ spec:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container-amd64.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
-        value: $(tasks.build-container.results.IMAGE_URL)
+        value: $(tasks.build-container-amd64.results.IMAGE_URL)
       - name: IMAGE_DIGEST
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
+        value: $(tasks.build-container-amd64.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:


### PR DESCRIPTION
This way we get around the issue that the deprecated-iamge-check doesn't support checking image indexes.