### PR TITLE
Update parameter for deprecated image check

### DIFF
--- a/.tekton/golden-container-pull-request.yaml
+++ b/.tekton/golden-container-pull-request.yaml
@@ -349,9 +349,9 @@ spec:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container-amd64.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
-        value: $(tasks.build-container-amd64.results.IMAGE_URL)
+        value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST
-        value: $(tasks.build-container-amd64.results.IMAGE_DIGEST)
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/golden-container-push.yaml
+++ b/.tekton/golden-container-push.yaml
@@ -346,9 +346,9 @@ spec:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container-amd64.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
-        value: $(tasks.build-container-amd64.results.IMAGE_URL)
+        value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST
-        value: $(tasks.build-container-amd64.results.IMAGE_DIGEST)
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:


### PR DESCRIPTION
With the parameter specifying amd64, that is the only digest checked, so switching to build-container. The violation thrown

```
 "violations": [
        {
          "msg": "Test 'deprecated-image-check' did not process image with digest 'sha256:69a1b4c814235755b22e907d1891bedfdfb4b2df39c06252d63a7acb518fa76e'.",
          "metadata": {
            "code": "test.test_all_images",
            "effective_on": "2024-05-29T00:00:00Z"
          }
        }
      ],
```