### PR TITLE
Remove sbom-json-check Task

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -430,28 +430,6 @@ spec:
           operator: in
           values:
             - "false"
-    - name: sbom-json-check
-      params:
-        - name: IMAGE_URL
-          value: $(tasks.build-container.results.IMAGE_URL)
-        - name: IMAGE_DIGEST
-          value: $(tasks.build-container.results.IMAGE_DIGEST)
-      runAfter:
-        - build-container
-      taskRef:
-        params:
-          - name: name
-            value: sbom-json-check
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.2@sha256:3e7af29bf02cad82d05e3722df6407b57e5b3e9a5bb011e1858f0876146e6da5
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(params.skip-checks)
-          operator: in
-          values:
-            - "false"
   workspaces:
     - name: workspace
     - name: git-auth


### PR DESCRIPTION
`sbom-json-check` Task has been deprecated and should be removed from the pipeline.