### PR TITLE
Fix cosign attest predicate type for SPDX JSON

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
     - name: Generate and store SBOM
       run: |
           syft "${IMAGE_REGISTRY}/${IMAGE_REPO}@${DIGEST}" -o spdx-json=sbom-spdx.json
-          cosign attest --yes --predicate sbom-spdx.json --type spdx "${IMAGE_REGISTRY}/${IMAGE_REPO}@${DIGEST}"
+          cosign attest --yes --predicate sbom-spdx.json --type spdxjson "${IMAGE_REGISTRY}/${IMAGE_REPO}@${DIGEST}"
       env:
         DIGEST: ${{ steps.push-image.outputs.digest }}
 


### PR DESCRIPTION
Use `--type spdxjson` instead of `--type spdx` when attesting the SBOM, since syft outputs JSON format.
The mismatch caused cosign to fail with `invalid attestation: decoding json`.

This should fix pipeline failures like this one: https://github.com/conforma/golden-container/actions/runs/23592271783/job/68700169912